### PR TITLE
add Hetzner DNS <-> hcloud pairing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
       nixosModules.default = ./modules;
       nixosModules.forgejo = ./services/forgejo/module.nix;
       nixosModules.keycloak = ./services/keycloak/module.nix;
+      nixosModules.hetzner-dns = ./services/hetzner-dns/module.nix;
 
       nixosConfigurations = lib.mapAttrs' (
         name: cfg: lib.nameValuePair "example-${name}" (exampleSystem "x86_64-linux" cfg)
@@ -45,6 +46,10 @@
           inherit (inputs) self;
         }
         // (import ./services/keycloak/checks.nix {
+          inherit pkgs;
+          inherit (inputs) self;
+        })
+        // (import ./services/hetzner-dns/checks.nix {
           inherit pkgs;
           inherit (inputs) self;
         })

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ../services/forgejo/module.nix
+    ../services/hetzner-dns/module.nix
     ../services/keycloak/module.nix
   ];
 }

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -458,7 +458,8 @@ rec {
   #   name        unit + generated-config name (e.g. "declarative-forgejo")
   #   tfConfig    the .tf.json config to apply
   #   afterUnits  units to order/require after (the service's main unit)
-  #   healthUrl   url polled until the service answers, before applying
+  #   healthUrl   url polled until the service answers, before applying; null
+  #               skips health check
   #   tokenFile   path to the admin token on the host, read via LoadCredential
   #   executor    OpenTofu wrapped with the pairing's provider (offline)
   #   tokenVar    name of the sensitive tf variable carrying the token; also
@@ -479,7 +480,7 @@ rec {
       name,
       tfConfig,
       afterUnits,
-      healthUrl,
+      healthUrl ? null,
       tokenFile,
       executor,
       tokenVar,
@@ -551,13 +552,15 @@ rec {
         # refresh the generated config (tfstate persists across runs).
         install -m 0600 ${confFile} ./main.tf.json
 
-        # wait for the service to actually answer before applying.
-        for _ in $(seq 1 60); do
-          if curl -fsS -o /dev/null "${healthUrl}"; then
-            break
-          fi
-          sleep 2
-        done
+        ${lib.optionalString (healthUrl != null) ''
+          # wait for the service to actually answer before applying.
+          for _ in $(seq 1 60); do
+            if curl -fsS -o /dev/null "${healthUrl}"; then
+              break
+            fi
+            sleep 2
+          done
+        ''}
 
         # pass each credential to tofu as TF_VAR_<id>.
         for id in ${lib.escapeShellArgs (lib.attrNames allCredentials)}; do

--- a/services/hetzner-dns/README.md
+++ b/services/hetzner-dns/README.md
@@ -1,0 +1,194 @@
+# Hetzner DNS
+
+Declaratively manage [Hetzner DNS](https://docs.hetzner.cloud/reference/cloud#zones)
+zones and records from NixOS: DNS zones, resource record sets (RRSets),
+individual records, and secondary (slave) zones.
+
+DNS is managed through the [`hetznercloud/hcloud`][hetznercloud/hcloud] provider.
+
+[provider]: https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs
+
+## Installation
+
+### Include the module
+
+Add this flake as an input and import its `nixosModules.hetzner-dns` into your
+host. Pointing the input's `nixpkgs` at your own keeps the provider build in
+step with the rest of your system.
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # This repository.
+    declarative-runtime.url = "github:youruser/declarative-runtime";
+    declarative-runtime.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    { nixpkgs, declarative-runtime, ... }:
+    {
+      nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          declarative-runtime.nixosModules.hetzner-dns
+          ./host.nix
+        ];
+      };
+    };
+}
+```
+
+### Provide an API token
+
+Create a Hetzner Cloud API token with DNS permissions ("Security > API tokens"
+in the Hetzner Cloud console) and place it on the target host — e.g. via
+sops-nix or agenix. Point `tokenFile` at that host path. `tokenFile` is
+required: a cloud API token cannot be self-bootstrapped.
+
+## Configuration examples
+
+Declare the desired state under `services.hetzner-dns.runtime`. Each entry's
+attributes are **typed options** named after the provider's snake_case
+attributes.
+
+### A zone with records (recommended)
+
+`zone_rrsets` is the recommended way to manage records: one entry per
+name+type, holding every value for that pair.
+
+```nix
+{
+  services.hetzner-dns.runtime = {
+    enable = true;
+    tokenFile = "/run/secrets/hcloud-dns-token";
+
+    zones.acme = {
+      name = "acme.example";
+      ttl = 3600;
+      labels.team = "platform";
+    };
+
+    zone_rrsets.www = {
+      zone = "acme";
+      name = "www"; # "@" for the apex, "*" for a wildcard
+      type = "A";
+      ttl = 300;
+      records = [
+        { value = "203.0.113.10"; }
+        { value = "203.0.113.11"; comment = "second frontend"; }
+      ];
+    };
+
+    zone_rrsets.apex_txt = {
+      zone = "acme";
+      name = "@";
+      type = "TXT";
+      records = [ { value = ''"v=spf1 include:_spf.example -all"''; } ];
+    };
+
+    zone_rrsets.mail = {
+      zone = "acme";
+      name = "@";
+      type = "MX";
+      records = [ { value = "10 mail.acme.example"; } ];
+    };
+  };
+}
+```
+
+### A single record (`zone_records`)
+
+Use `zone_records` only when a single record must be managed independently of
+the rest of its RRSet (it drives the `add_records`/`remove_records` API). Never
+manage the same name+type with both a `zone_rrsets` **and** a `zone_records`
+entry — they would fight over the set.
+
+```nix
+services.hetzner-dns.runtime.zone_records.legacy_a = {
+  zone = "acme";
+  name = "legacy";
+  type = "A";
+  value = "203.0.113.99";
+  comment = "kept for the old load balancer";
+};
+```
+
+### A zone managed elsewhere
+
+`zone` also accepts a literal Hetzner zone name or numeric ID, for records in a
+zone you do not manage from this host:
+
+```nix
+services.hetzner-dns.runtime.zone_rrsets.status = {
+  zone = "shared.example";
+  name = "status";
+  type = "CNAME";
+  records = [ { value = "status.hosted.example."; } ];
+};
+```
+
+### A secondary zone
+
+For a `secondary` zone, Hetzner slaves records from your own primary
+nameservers; set `primary_nameservers` and leave the records to the primary.
+The TSIG key authenticating zone transfers is a secret — supply it via
+`tsig_keyFile`.
+
+```nix
+services.hetzner-dns.runtime.zones.mirror = {
+  name = "mirror.example";
+  mode = "secondary";
+  primary_nameservers = [
+    {
+      address = "203.0.113.53";
+      tsig_algorithm = "hmac-sha256";
+      tsig_keyFile = "/run/secrets/mirror-tsig";
+    }
+  ];
+};
+```
+
+## Module options (`services.hetzner-dns.runtime`)
+
+| Option      | Type        | Default                        | Purpose                                                                             |
+| ----------- | ----------- | ------------------------------ | ----------------------------------------------------------------------------------- |
+| `enable`    | bool        | `false`                        | Turn on the reconciler.                                                             |
+| `tokenFile` | null or str | `null`                         | **Required.** Host path to a Hetzner Cloud API token.                               |
+| `endpoint`  | str         | `https://api.hetzner.cloud/v1` | Hetzner Cloud API base URL. Override only for a self-hosted proxy or a test double. |
+
+Plus one collection option per provider resource (next section).
+
+## Resources
+
+| Option         | `hcloud_*` resource | Key defaults | Reference inputs        |
+| -------------- | ------------------- | ------------ | ----------------------- |
+| `zones`        | `zone`              | `name`       | —                       |
+| `zone_rrsets`  | `zone_rrset`        | —            | `zone` → zone (name/ID) |
+| `zone_records` | `zone_record`       | —            | `zone` → zone (name/ID) |
+
+Notes:
+
+- Apex `SOA`/`NS` RRSets are created and managed by Hetzner; do not declare them.
+- `zones.<name>.mode` defaults to `"primary"`. `primary_nameservers` is required
+  for `"secondary"` zones and forbidden for `"primary"` ones (enforced by the
+  provider at apply).
+- The reconciler keeps its Terraform state under
+  `/var/lib/declarative-hetzner-dns`, owned by a dedicated `declarative-hetzner-dns`
+  system user.
+
+## Security note
+
+The API token always flows through systemd `LoadCredential=` into the sensitive
+`hcloud_token` Terraform variable — the generated `.tf.json` holds only a
+`${var.hcloud_token}` reference, never the literal.
+
+The per-record TSIG secret (`tsig_key` on a secondary zone's
+`primary_nameservers`) supports a `tsig_keyFile` form that takes a **host file
+path** instead of the literal value. The file is read at apply time via
+`LoadCredential=` into its own sensitive variable and **never enters the Nix
+store**; the generated `.tf.json` holds only a `${var.…}` reference. `tsig_key`
+and `tsig_keyFile` are mutually exclusive — prefer `tsig_keyFile` for any real
+key. Setting `tsig_key` literally renders the value verbatim into the
+**world-readable** `.tf.json` store path; use it only for throwaway values.

--- a/services/hetzner-dns/checks.nix
+++ b/services/hetzner-dns/checks.nix
@@ -1,0 +1,174 @@
+# hetzner-dns — Full integration test.
+# Hetzner DNS is a remote cloud API with. We emulate it with ./emulator.py.
+{ pkgs, self }:
+let
+  port = 8899;
+  apiToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  tsigSecret = "hackme";
+  endpoint = "http://127.0.0.1:${toString port}/v1";
+  tfJson = "/var/lib/declarative-hetzner-dns/declarative-terraform/main.tf.json";
+in
+{
+  hetzner-dns = pkgs.testers.runNixOSTest {
+    name = "declarative-hetzner-dns";
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        imports = [ self.nixosModules.default ];
+        environment.systemPackages = [ pkgs.curl ];
+        environment.etc."hcloud-dns-token".text = apiToken;
+        environment.etc."hcloud-tsig-key".text = tsigSecret;
+        systemd.services.hetzner-dns-emulator = {
+          description = "Hetzner DNS API test double";
+          wantedBy = [ "multi-user.target" ];
+          environment = {
+            PORT = toString port;
+            EXPECTED_TOKEN = apiToken;
+          };
+          serviceConfig = {
+            ExecStart = "${pkgs.python3}/bin/python3 ${./emulator.py}";
+            # TODO
+            ExecStartPost = "${pkgs.curl}/bin/curl --retry 30 --retry-delay 1 --retry-all-errors -fsS -o /dev/null http://127.0.0.1:${toString port}/v1/healthz";
+            DynamicUser = true;
+            Restart = "on-failure";
+          };
+        };
+
+        systemd.services.declarative-hetzner-dns = {
+          after = [ "hetzner-dns-emulator.service" ];
+          wants = [ "hetzner-dns-emulator.service" ];
+        };
+
+        services.hetzner-dns.runtime = {
+          enable = true;
+          tokenFile = "/etc/hcloud-dns-token";
+          inherit endpoint;
+
+          # canonical
+          zones.acme = {
+            name = "acme.example";
+            ttl = 3600;
+            labels.team = "platform";
+            delete_protection = false;
+          };
+
+          # nested secret
+          zones.mirror = {
+            name = "mirror.example";
+            mode = "secondary";
+            primary_nameservers = [
+              {
+                address = "203.0.113.53";
+                tsig_algorithm = "hmac-sha256";
+                tsig_keyFile = "/etc/hcloud-tsig-key";
+              }
+            ];
+          };
+
+          # multi-records
+          zone_rrsets.www = {
+            zone = "acme";
+            name = "www";
+            type = "A";
+            ttl = 300;
+            records = [
+              { value = "203.0.113.10"; }
+              { value = "203.0.113.11"; }
+            ];
+          };
+          zone_rrsets.apex_txt = {
+            zone = "acme";
+            name = "@";
+            type = "TXT";
+            records = [ { value = "\"v=spf1 -all\""; } ];
+          };
+
+          # mx record
+          zone_records.mx = {
+            zone = "acme";
+            name = "@";
+            type = "MX";
+            value = "10 mail.acme.example";
+            comment = "primary mx";
+          };
+        };
+
+        virtualisation.memorySize = 2048;
+
+        specialisation.addRecord.configuration = {
+          services.hetzner-dns.runtime.zone_rrsets.api = {
+            zone = "acme";
+            name = "api";
+            type = "A";
+            records = [ { value = "203.0.113.20"; } ];
+          };
+        };
+      };
+
+    testScript = ''
+      PORT = ${toString port}
+      TOKEN = "${apiToken}"
+      TSIG = "${tsigSecret}"
+      TFJSON = "${tfJson}"
+
+      def api(path):
+          return machine.succeed(
+              f"curl --fail -H 'Authorization: Bearer {TOKEN}' "
+              f"http://127.0.0.1:{PORT}/v1{path}"
+          )
+
+      machine.start()
+      machine.wait_for_unit("hetzner-dns-emulator.service")
+
+      machine.wait_for_unit("declarative-hetzner-dns.service")
+
+      # assert config
+      zone = api("/zones/acme.example")
+      assert '"team": "platform"' in zone, f"zone label not applied: {zone}"
+      assert '"ttl": 3600' in zone, f"zone ttl not applied: {zone}"
+
+      www = api("/zones/acme.example/rrsets/www/A")
+      assert '"203.0.113.10"' in www and '"203.0.113.11"' in www, f"www A not applied: {www}"
+
+      txt = api("/zones/acme.example/rrsets/@/TXT")
+      assert "v=spf1 -all" in txt, f"apex TXT not applied: {txt}"
+
+      mx = api("/zones/acme.example/rrsets/@/MX")
+      assert "10 mail.acme.example" in mx, f"MX record not applied: {mx}"
+
+      mirror = api("/zones/mirror.example")
+      assert '"mode": "secondary"' in mirror, f"secondary zone not applied: {mirror}"
+      assert f'"tsig_key": "{TSIG}"' in mirror, f"tsig key did not reach API: {mirror}"
+
+      # check secrets
+      tfjson = machine.succeed(f"cat {TFJSON}")
+      assert TOKEN not in tfjson, "API token leaked into generated .tf.json"
+      assert TSIG not in tfjson, "TSIG secret leaked into generated .tf.json"
+
+      # check state owner
+      owner = machine.succeed(
+          "stat -c %U /var/lib/declarative-hetzner-dns/declarative-terraform/terraform.tfstate"
+      ).strip()
+      assert owner == "declarative-hetzner-dns", f"tfstate not owned by service user: {owner}"
+
+      # idempotent
+      machine.succeed("systemctl restart declarative-hetzner-dns.service")
+      apply_lines = machine.succeed(
+          "journalctl -u declarative-hetzner-dns.service --no-pager --output=cat "
+          "| grep 'Apply complete'"
+      ).strip().splitlines()
+      assert apply_lines, "no 'Apply complete!' line in journal"
+      assert "0 added, 0 changed, 0 destroyed" in apply_lines[-1], \
+          f"reapply was not a no-op: {apply_lines[-1]}"
+
+      # restart triggers
+      machine.succeed("/run/current-system/specialisation/addRecord/bin/switch-to-configuration test")
+      api_ = machine.wait_until_succeeds(
+          f"curl --fail -H 'Authorization: Bearer {TOKEN}' "
+          f"http://127.0.0.1:{PORT}/v1/zones/acme.example/rrsets/api/A"
+      )
+      assert '203.0.113.20' in api_, f"api A not applied: {api_}"
+    '';
+  };
+}

--- a/services/hetzner-dns/emulator.py
+++ b/services/hetzner-dns/emulator.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+import json, os, re, sys, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+EXPECTED_TOKEN = os.environ.get("EXPECTED_TOKEN") or None
+LISTEN = int(os.environ.get("PORT", "8080"))
+
+lock = threading.Lock()
+zones = {}
+name_to_id = {}
+rrsets = {}
+seq = {"zone": 0, "action": 0}
+NOW = "2024-01-01T00:00:00+00:00"
+
+
+def next_id(kind):
+    seq[kind] += 1
+    return seq[kind]
+
+
+def action(command):
+    return {
+        "id": next_id("action"),
+        "status": "success",
+        "command": command,
+        "progress": 100,
+        "started": NOW,
+        "finished": NOW,
+        "error": None,
+        "resources": [],
+    }
+
+
+def resolve_zone(id_or_name):
+    if id_or_name in name_to_id:
+        return name_to_id[id_or_name]
+    try:
+        zid = int(id_or_name)
+    except ValueError:
+        return None
+    return zid if zid in zones else None
+
+
+def zone_view(z):
+    return {
+        "id": z["id"],
+        "name": z["name"],
+        "created": NOW,
+        "ttl": z["ttl"],
+        "mode": z["mode"],
+        "primary_nameservers": z["primary_nameservers"],
+        "protection": {"delete": z["delete"]},
+        "labels": z["labels"],
+        "authoritative_nameservers": {
+            "assigned": ["hydrogen.ns.hetzner.com"],
+            "delegated": [],
+            "delegation_last_check": None,
+            "delegation_status": "unregistered",
+        },
+        "registrar": "unknown",
+        "status": "ok",
+        "record_count": sum(
+            1 for k in rrsets if k[0] == z["id"]
+        ),
+    }
+
+
+def rrset_view(r):
+    return {
+        "id": f'{r["name"]}/{r["type"]}',
+        "name": r["name"],
+        "type": r["type"],
+        "ttl": r["ttl"],
+        "labels": r["labels"],
+        "protection": {"change": r["change"]},
+        "records": r["records"],
+        "zone": r["zone_id"],
+    }
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        sys.stderr.write("EMU %s %s\n" % (self.command, self.path))
+
+    def _send(self, code, body):
+        data = json.dumps(body).encode() if body is not None else b""
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        if data:
+            self.wfile.write(data)
+
+    def _err(self, code, ecode, msg):
+        self._send(code, {"error": {"code": ecode, "message": msg}})
+
+    def _body(self):
+        n = int(self.headers.get("Content-Length", "0") or "0")
+        if not n:
+            return {}
+        return json.loads(self.rfile.read(n) or b"{}")
+
+    def _auth_ok(self):
+        if EXPECTED_TOKEN is None:
+            return True
+        got = self.headers.get("Authorization", "")
+        return got == f"Bearer {EXPECTED_TOKEN}"
+
+    def _path(self):
+        p = self.path.split("?", 1)[0]
+        if p.startswith("/v1"):
+            p = p[3:]
+        return p.rstrip("/") or "/"
+
+    def do_GET(self):
+        p = self._path()
+        if p == "/healthz":
+            return self._send(200, {"ok": True})
+        if not self._auth_ok():
+            return self._err(401, "unauthorized", "invalid token")
+        with lock:
+            self._route_get(p)
+
+    def do_POST(self):
+        if not self._auth_ok():
+            return self._err(401, "unauthorized", "invalid token")
+        with lock:
+            self._route_post(self._path(), self._body())
+
+    def do_PUT(self):
+        if not self._auth_ok():
+            return self._err(401, "unauthorized", "invalid token")
+        with lock:
+            self._route_put(self._path(), self._body())
+
+    def do_DELETE(self):
+        if not self._auth_ok():
+            return self._err(401, "unauthorized", "invalid token")
+        with lock:
+            self._route_delete(self._path())
+
+    def _route_get(self, p):
+        m = re.fullmatch(r"/zones", p)
+        if m:
+            return self._send(200, {"zones": [zone_view(z) for z in zones.values()],
+                                    "meta": {"pagination": {"page": 1, "per_page": 50, "next_page": None, "total_entries": len(zones)}}})
+        m = re.fullmatch(r"/zones/([^/]+)/rrsets", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            rs = [rrset_view(r) for k, r in rrsets.items() if k[0] == zid]
+            return self._send(200, {"rrsets": rs,
+                                    "meta": {"pagination": {"page": 1, "per_page": 50, "next_page": None, "total_entries": len(rs)}}})
+        m = re.fullmatch(r"/zones/([^/]+)/rrsets/([^/]+)/([^/]+)", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            r = rrsets.get((zid, m.group(2), m.group(3)))
+            if r is None:
+                return self._err(404, "not_found", "rrset not found")
+            return self._send(200, {"rrset": rrset_view(r)})
+        m = re.fullmatch(r"/zones/([^/]+)", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            if zid is None:
+                return self._err(404, "not_found", "zone not found")
+            return self._send(200, {"zone": zone_view(zones[zid])})
+        m = re.fullmatch(r"/actions/(\d+)", p)
+        if m:
+            return self._send(200, {"action": action("noop")})
+        if p == "/actions":
+            return self._send(200, {"actions": [], "meta": {"pagination": {"page": 1, "per_page": 50, "next_page": None, "total_entries": 0}}})
+        return self._err(404, "not_found", "no route %s" % p)
+
+    def _route_post(self, p, body):
+        m = re.fullmatch(r"/zones", p)
+        if m:
+            zid = next_id("zone")
+            z = {
+                "id": zid,
+                "name": body["name"],
+                "mode": body.get("mode", "primary"),
+                "ttl": body.get("ttl") if body.get("ttl") is not None else 3600,
+                "labels": body.get("labels") or {},
+                "delete": False,
+                "primary_nameservers": body.get("primary_nameservers") or [],
+            }
+            zones[zid] = z
+            name_to_id[z["name"]] = zid
+            return self._send(201, {"zone": zone_view(z), "action": action("create_zone")})
+        m = re.fullmatch(r"/zones/([^/]+)/rrsets", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            if zid is None:
+                return self._err(404, "not_found", "zone not found")
+            r = {
+                "zone_id": zid,
+                "name": body["name"],
+                "type": body["type"],
+                "ttl": body.get("ttl"),
+                "labels": body.get("labels") or {},
+                "change": False,
+                "records": body.get("records") or [],
+            }
+            rrsets[(zid, r["name"], r["type"])] = r
+            return self._send(201, {"rrset": rrset_view(r), "action": action("create_rrset")})
+        m = re.fullmatch(r"/zones/([^/]+)/actions/(\w+)", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            act = m.group(2)
+            z = zones.get(zid)
+            if z is None:
+                return self._err(404, "not_found", "zone not found")
+            if act == "change_protection" and "delete" in body:
+                z["delete"] = bool(body["delete"])
+            elif act == "change_ttl":
+                z["ttl"] = body["ttl"]
+            elif act == "change_primary_nameservers":
+                z["primary_nameservers"] = body.get("primary_nameservers") or []
+            return self._send(201, {"action": action(act)})
+        m = re.fullmatch(r"/zones/([^/]+)/rrsets/([^/]+)/([^/]+)/actions/(\w+)", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            name, typ, act = m.group(2), m.group(3), m.group(4)
+            key = (zid, name, typ)
+            r = rrsets.get(key)
+            if act in ("add_records",) and r is None:
+                # add_records implicitly creates the rrset (zone_record path)
+                r = {"zone_id": zid, "name": name, "type": typ, "ttl": body.get("ttl"),
+                     "labels": {}, "change": False, "records": []}
+                rrsets[key] = r
+            if r is None:
+                return self._err(404, "not_found", "rrset not found")
+            if act == "set_records":
+                r["records"] = body.get("records") or []
+            elif act == "add_records":
+                have = {(x["value"]) for x in r["records"]}
+                for rec in body.get("records") or []:
+                    if rec["value"] not in have:
+                        r["records"].append(rec)
+                if body.get("ttl") is not None:
+                    r["ttl"] = body["ttl"]
+            elif act == "update_records":
+                for rec in body.get("records") or []:
+                    for x in r["records"]:
+                        if x["value"] == rec["value"]:
+                            x["comment"] = rec.get("comment", "")
+            elif act == "remove_records":
+                vals = {x["value"] for x in (body.get("records") or [])}
+                r["records"] = [x for x in r["records"] if x["value"] not in vals]
+            elif act == "change_protection" and "change" in body:
+                r["change"] = bool(body["change"])
+            elif act == "change_ttl":
+                r["ttl"] = body.get("ttl")
+            return self._send(201, {"action": action(act)})
+        return self._err(404, "not_found", "no route %s" % p)
+
+    def _route_put(self, p, body):
+        m = re.fullmatch(r"/zones/([^/]+)/rrsets/([^/]+)/([^/]+)", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            r = rrsets.get((zid, m.group(2), m.group(3)))
+            if r is None:
+                return self._err(404, "not_found", "rrset not found")
+            if "labels" in body and body["labels"] is not None:
+                r["labels"] = body["labels"]
+            return self._send(200, {"rrset": rrset_view(r)})
+        m = re.fullmatch(r"/zones/([^/]+)", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            if zid is None:
+                return self._err(404, "not_found", "zone not found")
+            z = zones[zid]
+            if "labels" in body and body["labels"] is not None:
+                z["labels"] = body["labels"]
+            return self._send(200, {"zone": zone_view(z)})
+        return self._err(404, "not_found", "no route %s" % p)
+
+    def _route_delete(self, p):
+        m = re.fullmatch(r"/zones/([^/]+)/rrsets/([^/]+)/([^/]+)", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            rrsets.pop((zid, m.group(2), m.group(3)), None)
+            return self._send(200, {"action": action("delete_rrset")})
+        m = re.fullmatch(r"/zones/([^/]+)", p)
+        if m:
+            zid = resolve_zone(m.group(1))
+            if zid is not None:
+                z = zones.pop(zid, None)
+                if z:
+                    name_to_id.pop(z["name"], None)
+                for k in [k for k in rrsets if k[0] == zid]:
+                    rrsets.pop(k, None)
+            return self._send(200, {"action": action("delete_zone")})
+        return self._err(404, "not_found", "no route %s" % p)
+
+
+if __name__ == "__main__":
+    srv = ThreadingHTTPServer(("127.0.0.1", LISTEN), H)
+    sys.stderr.write("emulator listening on %d\n" % LISTEN)
+    srv.serve_forever()

--- a/services/hetzner-dns/lib.nix
+++ b/services/hetzner-dns/lib.nix
@@ -1,0 +1,138 @@
+{ pkgs }:
+let
+  genlib = import ../../modules/lib { inherit pkgs; };
+  inherit (genlib)
+    oStr
+    oBool
+    oInt
+    oAttrsStr
+    oListSub
+    rStr
+    ;
+  inherit (pkgs) lib;
+  ty = lib.types;
+
+  provider = pkgs.terraform-providers.hetznercloud_hcloud;
+  providerVersion = provider.version;
+  # The Hetzner Cloud API token; exposed to OpenTofu as the sensitive
+  # `hcloud_token` variable/ `TF_VAR_hcloud_token`.
+  tokenVar = "hcloud_token";
+  executor = pkgs.opentofu.withPlugins (_: [ provider ]);
+
+  recordSubmodule = ty.submodule {
+    options = {
+      value = rStr "Value of the record (e.g. an IPv4/IPv6 address, target host, or a quoted TXT string).";
+      comment = oStr "Optional comment for this record.";
+    };
+  };
+
+  # ID or Name of a parent zone. Managed zones resolve to
+  # `${hcloud_zone.<label>.id}`; other values pass as it.
+  zoneRef = {
+    attr = "zone";
+    targets = [
+      {
+        collection = "zones";
+        field = "id";
+      }
+    ];
+    managedOnly = false;
+    required = true;
+    description = "Parent zone: the key of a managed zone, or a literal Hetzner zone name/ID for a zone managed elsewhere.";
+  };
+
+  # The DNS resource surface of the hetznercloud/hcloud provider. Per resource:
+  #   type            the `hcloud_*` resource type
+  #   prefix          unique Terraform label prefix
+  #   nameAttr        attribute defaulted from the collection key (or null)
+  #   refs            parent links resolved to references against managed zones
+  #   requiredAttrs   collection attrs that must be present and non-empty
+  #   attrs           the settable attributes, each a typed option (no freeform)
+  # Computed/output-only attributes (id, registrar, authoritative_nameservers,
+  # protection read-back, ...) are intentionally omitted.
+  resourceTypes = {
+    zones = {
+      type = "hcloud_zone";
+      prefix = "zone";
+      nameAttr = "name";
+      refs = { };
+      description = "Hetzner DNS zones, keyed by zone (domain) name.";
+      attrs = {
+        name = oStr "Name of the zone (domain, e.g. \"example.com\"). Defaults to the attribute key.";
+        mode = lib.mkOption {
+          type = ty.str;
+          default = "primary";
+          description = ''
+            Zone mode: "primary" (Hetzner is authoritative; manage records here)
+            or "secondary" (Hetzner slaves the zone from your own primaries -- set
+            `primary_nameservers` and leave records to the primary).
+          '';
+        };
+        ttl = oInt "Default TTL (seconds) for the zone's records (provider default 3600).";
+        labels = oAttrsStr "User-defined labels (key/value pairs) attached to the zone.";
+        delete_protection = oBool "Protect the zone from deletion.";
+        primary_nameservers =
+          oListSub
+            {
+              address = rStr "Public IPv4 or IPv6 address of the primary nameserver.";
+              port = oInt "Port of the primary nameserver (default 53).";
+              tsig_algorithm = oStr "TSIG algorithm (e.g. \"hmac-sha256\") used to sign zone transfers.";
+              tsig_key = oStr "TSIG key authenticating zone transfers. Prefer `tsig_keyFile` to keep the secret out of the world-readable store.";
+              tsig_keyFile = oStr "Runtime path to a file holding the TSIG key (loaded via systemd LoadCredential=; never copied to the store). Mutually exclusive with a literal `tsig_key`.";
+            }
+            "Primary nameservers Hetzner transfers a secondary zone from. Required when `mode = \"secondary\"`, forbidden when `mode = \"primary\"`.";
+      };
+    };
+
+    zone_rrsets = {
+      type = "hcloud_zone_rrset";
+      prefix = "rrset";
+      nameAttr = null;
+      refs.zone = zoneRef;
+      requiredAttrs = [ "records" ];
+      description = "Hetzner DNS resource record sets (all records sharing a name+type), keyed by an arbitrary label. The recommended way to manage records.";
+      attrs = {
+        name = rStr "Record name relative to the zone: \"@\" for the apex, or a label such as \"www\" or \"*\".";
+        type = rStr "RRSet type: A, AAAA, CNAME, MX, TXT, SRV, NS, CAA, DS, PTR, TLSA, ... (SOA/NS at the apex are managed by Hetzner).";
+        ttl = oInt "TTL (seconds) for this RRSet; falls back to the zone default when unset.";
+        labels = oAttrsStr "User-defined labels (key/value pairs) attached to the RRSet.";
+        change_protection = oBool "Protect the RRSet's records from changes.";
+        records = lib.mkOption {
+          type = ty.listOf recordSubmodule;
+          description = "The records making up this set (at least one). For TXT, each value must be one or more quoted 255-char strings.";
+        };
+      };
+    };
+
+    zone_records = {
+      type = "hcloud_zone_record";
+      prefix = "record";
+      nameAttr = null;
+      refs.zone = zoneRef;
+      description = "Individual Hetzner DNS records, keyed by an arbitrary label. Prefer `zone_rrsets`; use this only when a single record must be managed independently of the rest of its RRSet (never manage the same name+type with both).";
+      attrs = {
+        name = rStr "Record name relative to the zone: \"@\" for the apex, or a label such as \"www\".";
+        type = rStr "Record type (A, AAAA, CNAME, MX, TXT, ...).";
+        value = rStr "Value of the record (e.g. an IPv4/IPv6 address, target host, or a quoted TXT string).";
+        comment = oStr "Optional comment for the record.";
+      };
+    };
+  };
+
+  # cfg -> { config; credentials; }. `config` carries no secrets
+  hetznerDnsTfConfig = genlib.mkTfConfig {
+    inherit resourceTypes providerVersion tokenVar;
+    providerName = "hcloud";
+    providerSource = "hetznercloud/hcloud";
+    runtimePrefix = "services.hetzner-dns.runtime";
+    providerBlock = cfg: {
+      token = "\${var.${tokenVar}}";
+      inherit (cfg) endpoint;
+    };
+  };
+in
+{
+  inherit resourceTypes hetznerDnsTfConfig;
+  resourceOptions = genlib.resourceOptions resourceTypes;
+  mkReconcileService = args: genlib.mkReconcileService (args // { inherit executor tokenVar; });
+}

--- a/services/hetzner-dns/module.nix
+++ b/services/hetzner-dns/module.nix
@@ -1,0 +1,90 @@
+# Hetzner DNS <-> hetznercloud/hcloud pairing.
+#
+# Hetzner DNS is a *remote* managed service, not a local NixOS service: there
+# is no upstream `services.hetzner-dns` module to enable.
+#
+# Authentication is a Hetzner Cloud API token, which cannot be
+# self-bootstrapped.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+  cfg = config.services.hetzner-dns.runtime;
+  tflib = import ./lib.nix { inherit pkgs; };
+  serviceUser = "declarative-hetzner-dns";
+  stateDir = "/var/lib/declarative-hetzner-dns";
+  tf = tflib.hetznerDnsTfConfig cfg;
+in
+{
+  options.services.hetzner-dns.runtime = {
+    enable = mkEnableOption (
+      "declarative Hetzner DNS configuration, applied via OpenTofu and the "
+      + "hetznercloud/hcloud provider against the Hetzner DNS API"
+    );
+
+    tokenFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "/run/secrets/hcloud-dns-token";
+      description = ''
+        Runtime path to a file containing a Hetzner Cloud API token with
+        permission to manage DNS zones (created under "Security > API tokens"
+        in the Hetzner Cloud console).
+      '';
+    };
+
+    endpoint = mkOption {
+      type = types.str;
+      default = "https://api.hetzner.cloud/v1";
+      description = ''
+        Base URL of the Hetzner Cloud API the provider targets. Override only to
+        point at a self-hosted API proxy or a test double; the default is the
+        public Hetzner Cloud API (which serves the DNS zone/RRSet endpoints).
+      '';
+    };
+  }
+  // tflib.resourceOptions;
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.tokenFile != null;
+        message = "services.hetzner-dns.runtime.tokenFile is required: set it to a host path holding a Hetzner Cloud API token (DNS scope).";
+      }
+    ];
+
+    users.users.${serviceUser} = {
+      isSystemUser = true;
+      group = serviceUser;
+      home = stateDir;
+      description = "declarative Hetzner DNS reconciler";
+    };
+    users.groups.${serviceUser} = { };
+    systemd.tmpfiles.rules = [ "d ${stateDir} 0700 ${serviceUser} ${serviceUser} -" ];
+
+    systemd.services.declarative-hetzner-dns =
+      tflib.mkReconcileService {
+        name = "declarative-hetzner-dns";
+        tfConfig = tf.config;
+        inherit (tf) credentials;
+        afterUnits = [ ];
+        inherit (cfg) tokenFile;
+        user = serviceUser;
+        group = serviceUser;
+        inherit stateDir;
+      }
+      // {
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+      };
+  };
+}


### PR DESCRIPTION
Declaratively manage Hetzner DNS zones, RRSets, and individual records
via OpenTofu and the official hetznercloud/hcloud provider.

Unlike the local-service pairings this targets a remote cloud API: there
is no upstream service to enable, tokenFile is required, tfstate lives
under a dedicated declarative-hetzner-dns system user, and the
reconciler only waits for the network.

Checks are implemented using a local double of the Hetzner Cloud DNS API
(services/hetzner-dns/emulator.py).